### PR TITLE
Simplify seconds formatting algorithm

### DIFF
--- a/elapsed_time_block.py
+++ b/elapsed_time_block.py
@@ -85,8 +85,7 @@ class ElapsedTime(EnrichSignals, Block):
         least_significant_mult = 1
 
         if not any([days_enabled, hours_enabled, mins_enabled, secs_enabled]):
-            # Treat nothing enabled as all enabled
-            days_enabled = hours_enabled = mins_enabled = secs_enabled = True
+            return {}
 
         output = {}
 

--- a/elapsed_time_block.py
+++ b/elapsed_time_block.py
@@ -117,6 +117,8 @@ class ElapsedTime(EnrichSignals, Block):
             seconds = 0
 
         output[least_significant] += seconds / least_significant_mult
+        if secs_enabled and not self.milliseconds(signal):
+            output["seconds"] = int(output["seconds"])
 
         return output
 

--- a/elapsed_time_block.py
+++ b/elapsed_time_block.py
@@ -17,7 +17,7 @@ class Units(PropertyHolder):
     days = BoolProperty(title='Days', default=False, order=0)
     hours = BoolProperty(title='Hours', default=False, order=1)
     minutes = BoolProperty(title='Minutes', default=False, order=2)
-    seconds = BoolProperty(title='Seconds', default=False, order=3)
+    seconds = BoolProperty(title='Seconds', default=True, order=3)
 
 
 class ElapsedTime(EnrichSignals, Block):

--- a/tests/test_elapsed_time_block.py
+++ b/tests/test_elapsed_time_block.py
@@ -48,9 +48,6 @@ class TestElapsedTime(NIOBlockTestCase):
                 'timestamp_a': self.timestamp_a,
                 'timestamp_b': self.timestamp_b,
                 'timedelta': {
-                    'days': self.total_days,
-                    'hours': self.total_hours,
-                    'minutes': self.total_minutes,
                     'seconds': self.total_seconds,
                 },
             }),

--- a/tests/test_elapsed_time_block.py
+++ b/tests/test_elapsed_time_block.py
@@ -6,6 +6,20 @@ from nio.testing.block_test_case import NIOBlockTestCase
 from ..elapsed_time_block import ElapsedTime
 
 
+class RoundedSig(Signal):
+
+    def to_dict(self):
+        my_dict = super().to_dict()
+        for key, item in my_dict.items():
+            if not isinstance(item, dict):
+                continue
+            for attr, value in item.items():
+                if isinstance(value, float):
+                    my_dict[key][attr] = round(value, 6)
+        return my_dict
+
+
+@patch('nio.block.mixins.enrich.enrich_signals.Signal', side_effect=RoundedSig)
 class TestElapsedTime(NIOBlockTestCase):
 
     maxDiff = None
@@ -23,7 +37,7 @@ class TestElapsedTime(NIOBlockTestCase):
     total_hours = total_minutes / 60
     total_days = total_hours / 24
 
-    def test_default_config(self):
+    def test_default_config(self, Signal):
         """ Two timestamps in an incoming signal are compared."""
         blk = ElapsedTime()
         config = {
@@ -53,7 +67,7 @@ class TestElapsedTime(NIOBlockTestCase):
             }),
         ])
 
-    def test_advanced_configuration(self):
+    def test_advanced_configuration(self, Signal):
         """ Unit selection, output attribute, and enrichment options."""
         blk = ElapsedTime()
         config = {
@@ -295,7 +309,7 @@ class TestElapsedTime(NIOBlockTestCase):
             }),
         ])
 
-    def test_optional_milliseconds(self):
+    def test_optional_milliseconds(self, Signal):
         """ Milliseconds in incoming timestamps can optionally be truncated."""
         blk = ElapsedTime()
         config = {

--- a/tests/test_elapsed_time_block.py
+++ b/tests/test_elapsed_time_block.py
@@ -350,3 +350,29 @@ class TestElapsedTime(NIOBlockTestCase):
         # check that seconds was cast to int
         seconds = self.last_notified[DEFAULT_TERMINAL][0].timedelta['seconds']
         self.assertTrue(isinstance(seconds, int))
+
+    def test_nothing_checked(self, Signal):
+        """ Empty dict out when no values are checked """
+        blk = ElapsedTime()
+        config = {
+            'units': {
+                'days': False,
+                'hours': False,
+                'minutes': False,
+                'seconds': False,
+            },
+            'timestamp_a': '1984-05-03T00:00:00.999Z',
+            'timestamp_b': '1984-05-03T00:00:01.001Z',
+        }
+        self.configure_block(blk, config)
+
+        # process a list of signals
+        blk.start()
+        blk.process_signals([Signal()])
+        blk.stop()
+
+        self.assert_last_signal_list_notified([
+            Signal({
+                'timedelta': {},
+            }),
+        ])


### PR DESCRIPTION
This shows how I would do that dictionary format algorithm. Less nested conditionals and it just goes through the units from most-significant to least-significant, subtracting along the way. It could be shortened even more with a loop but this is more clear and readable I think.

This does not cover the following previous requirements though:
- seconds is an integer - this is just floating point math annoyance, I can fix if we want the hard req that seconds should be an int and not a rounded float when truncate is true:
```python
>>> 5 + 0/1
5.0
```
- all values disabled - previously unchecking all boxes would make the block act like each one had been checked by itself in its own configuration. Meaning `{days: 1.5, hours: 36...}` instead of `{days: 1, hours: 12...}`. I can add that requirement back in but it feels confusing. I'm not really sure what the desired behavior would be if they were all unchecked though.

The tests also fail because of annoying rounding math. Submitting this as a draft to start discussion, I'll clean up and fix the failing tests once ready.